### PR TITLE
Use custom cmake variable for project name and target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@
 # |_| |_|\___/_/\_\_| https://github.com/EmberEmu/hexi
 
 cmake_minimum_required(VERSION 3.29)
-project(hexi)
+set(HEXI_PROJECT_NAME hexi)
+project(${HEXI_PROJECT_NAME})
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED OFF)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -36,5 +36,5 @@ set(HEADERS
     hexi/allocators/block_allocator.h
 )
 
-add_library(${CMAKE_PROJECT_NAME} INTERFACE ${HEADERS})
-target_include_directories(${CMAKE_PROJECT_NAME} INTERFACE ../)
+add_library(${HEXI_PROJECT_NAME} INTERFACE ${HEADERS})
+target_include_directories(${HEXI_PROJECT_NAME} INTERFACE ../)


### PR DESCRIPTION
CMAKE_PROJECT_NAME is supposed to be the topmost project which means that it will propagate down to dependencies if those are included via FetchContent. This means that Hexi cannot be included in a project via FetchContent because the CMAKE_PROJECT_NAME is taken from the project it is being included by.

I ran into this issue when I tried to use hexi with FetchContent. I tried to find a way to make CMake work with this but I think according to the documentation, this is on purpose. There is even a variable that tells you whether or not you are the top level project probably to avoid issues like this. [Documentation can be found here](https://cmake.org/cmake/help/latest/command/project.html).

I didn't find a guide for contributing so I hope everything is to your liking. Let me know if you want something changed or change it yourself if that is fine with you.

I looked at your commit messages and it seems like you go for a descriptive title and a short explanation for the change. If you have issues with my commit message, please let me know and I reword it.