### PR TITLE
file_buffer: don't perform seeks at the end of find/read/write

### DIFF
--- a/include/hexi/file_buffer.h
+++ b/include/hexi/file_buffer.h
@@ -173,10 +173,6 @@ public:
 			error_ = true;
 			return;
 		}
-
-		if(std::fseek(file_, read_, SEEK_SET)) {
-			error_ = true;
-		}
 	}
 
 	/**
@@ -205,17 +201,8 @@ public:
 			}
 
 			if(buffer == val) {
-				if(std::fseek(file_, read_, SEEK_SET)) {
-					error_ = true;
-					return npos;
-				}
-
 				return i;
 			}
-		}
-
-		if(std::fseek(file_, read_, SEEK_SET)) {
-			error_ = true;
 		}
 
 		return npos;

--- a/single_include/hexi.h
+++ b/single_include/hexi.h
@@ -2927,10 +2927,6 @@ public:
 			error_ = true;
 			return;
 		}
-
-		if(std::fseek(file_, read_, SEEK_SET)) {
-			error_ = true;
-		}
 	}
 
 	/**
@@ -2959,17 +2955,8 @@ public:
 			}
 
 			if(buffer == val) {
-				if(std::fseek(file_, read_, SEEK_SET)) {
-					error_ = true;
-					return npos;
-				}
-
 				return i;
 			}
-		}
-
-		if(std::fseek(file_, read_, SEEK_SET)) {
-			error_ = true;
 		}
 
 		return npos;


### PR DESCRIPTION
fseek is performed at the beginning of each, so it's unnecessary