### PR TITLE
Add adaptors for better control over string encoding

### DIFF
--- a/include/hexi/pmc/binary_stream_reader.h
+++ b/include/hexi/pmc/binary_stream_reader.h
@@ -64,24 +64,64 @@ public:
 	binary_stream_reader& operator=(const binary_stream_reader&) = delete;
 	binary_stream_reader(const binary_stream_reader&) = delete;
 
-	// terminates when it hits a null byte, empty string if none found
-	binary_stream_reader& operator>>(std::string& dest) {
-		check_read_bounds(1); // just to prevent trying to read from an empty buffer
-		auto pos = buffer_.find_first_of(std::byte(0));
+	binary_stream_reader& operator>>(prefixed<std::string> adaptor) {
+		check_read_bounds(sizeof(std::string::size_type));
 
-		if(pos == buffer_read::npos) {
-			dest.clear();
-			return *this;
-		}
+		std::string::size_type size {};
+		buffer_.read(&size, sizeof(size));
+		endian::little_to_native_inplace(size);
 
-		dest.resize_and_overwrite(pos, [&](char* strbuf, std::size_t size) {
-			total_read_ += size;
+		check_read_bounds(size);
+
+		adaptor->resize_and_overwrite(size, [&](char* strbuf, std::size_t size) {
 			buffer_.read(strbuf, size);
 			return size;
 		});
 
-		buffer_.skip(1); // skip null term
 		return *this;
+	}
+	
+	binary_stream_reader& operator>>(prefixed_varint<std::string> adaptor) {
+		const auto& [result, size] = varint_decode<std::size_t>(*this);
+
+		// if decoding the varint failed due to detecting a potential read overrun,
+		// we'll trigger the error handling here instead
+		if(!result) {
+			check_read_bounds(1);
+			std::unreachable();
+		}
+
+		check_read_bounds(size);
+
+		adaptor->resize_and_overwrite(size, [&](char* strbuf, std::size_t size) {
+			buffer_.read(strbuf, size);
+			return size;
+		});
+
+		return *this;
+	}
+
+	binary_stream_reader& operator>>(null_terminated<std::string> adaptor) {
+		auto pos = buffer_.find_first_of(std::byte{0});
+
+		if(pos == buffer_.npos) {
+			adaptor->clear();
+			return *this;
+		}
+
+		check_read_bounds(pos + 1); // include null terminator
+
+		adaptor->resize_and_overwrite(pos, [&](char* strbuf, std::size_t size) {
+			buffer_.read(strbuf, pos);
+			return size;
+		});
+
+		buffer_.skip(1); // skip null terminator
+		return *this;
+	}
+
+	binary_stream_reader& operator >>(std::string& data) {
+		return (*this >> prefixed(data));
 	}
 
 	binary_stream_reader& operator>>(has_shr_override<binary_stream_reader> auto&& data) {
@@ -243,6 +283,24 @@ public:
 	 */
 	std::size_t read_limit() const {
 		return read_limit_;
+	}
+
+	/**
+	 * @brief Determine the maximum number of bytes that can be
+	 * safely read from this stream.
+	 * 
+	 * The value returned may be lower than the amount of data
+	 * available in the buffer if a read limit was set during
+	 * the stream's construction.
+	 * 
+	 * @return The number of bytes available for reading.
+	 */
+	std::size_t read_max() const {
+		if(read_limit_) {
+			return read_limit_ - total_read_;
+		} else {
+			return buffer_.size();
+		}
 	}
 
 	/**

--- a/include/hexi/pmc/binary_stream_writer.h
+++ b/include/hexi/pmc/binary_stream_writer.h
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -57,10 +58,56 @@ public:
 		return *this;
 	}
 
-	binary_stream_writer& operator<<(const std::string& data) {
-		buffer_.write(data.data(), data.size() + 1); // +1 also writes terminator
-		total_write_ += (data.size() + 1);
+	template<typename T>
+	binary_stream_writer& operator<<(prefixed<T> adaptor) {
+		const auto size = endian::native_to_little(adaptor->size());
+		buffer_.write(&size, sizeof(size));
+		buffer_.write(adaptor->data(), adaptor->size());
+		total_write_ += (adaptor->size()) + sizeof(adaptor->size());
 		return *this;
+	}
+
+	template<typename T>
+	binary_stream_writer& operator<<(prefixed_varint<T> adaptor) {
+		const auto encode_len = varint_encode(*this, adaptor->size());
+		buffer_.write(adaptor->data(), adaptor->size());
+		total_write_ += (adaptor->size() + encode_len);
+		return *this;
+	}
+
+	template<typename T>
+	requires std::is_same_v<std::decay_t<T>, std::string_view>
+	binary_stream_writer& operator<<(null_terminated<T> adaptor) {
+		assert(adaptor->find_first_of('\0') == adaptor->npos);
+		buffer_.write(adaptor->data(), adaptor->size());
+		const char terminator = '\0';
+		buffer_.write(&terminator, 1);
+		total_write_ += (adaptor->size() + 1);
+		return *this;
+	}
+
+	template<typename T>
+	requires std::is_same_v<std::decay_t<T>, std::string>
+	binary_stream_writer& operator<<(null_terminated<T> adaptor) {
+		assert(adaptor->find_first_of('\0') == adaptor->npos);
+		buffer_.write(adaptor->data(), adaptor->size() + 1); // yes, the standard allows this
+		total_write_ += (adaptor->size() + 1);
+		return *this;
+	}
+
+	template<typename T>
+	binary_stream_writer& operator<<(raw<T> adaptor) {
+		buffer_.write(adaptor->data(), adaptor->size());
+		total_write_ += adaptor->size();
+		return *this;
+	}
+
+	binary_stream_writer& operator<<(std::string_view string) {
+		return (*this << prefixed(string));
+	}
+
+	binary_stream_writer& operator<<(const std::string& string) {
+		return (*this << prefixed(string));
 	}
 
 	binary_stream_writer& operator<<(const char* data) {
@@ -68,14 +115,6 @@ public:
 		const auto len = std::strlen(data);
 		buffer_.write(data, len + 1); // include terminator
 		total_write_ += len + 1;
-		return *this;
-	}
-
-	binary_stream_writer& operator<<(std::string_view& data) {
-		buffer_.write(data.data(), data.size());
-		const char term = '\0';
-		buffer_.write(&term, sizeof(term));
-		total_write_ += (data.size() + 1);
 		return *this;
 	}
 

--- a/tests/binary_stream_pmc.cpp
+++ b/tests/binary_stream_pmc.cpp
@@ -86,13 +86,13 @@ TEST(binary_stream_pmc, read_write_std_string) {
 	hexi::dynamic_buffer<32> buffer;
 	hexi::pmc::binary_stream stream(buffer);
 	const std::string in { "The quick brown fox jumped over the lazy dog" };
-	stream << in;
+	stream << hexi::null_terminated(in);
 
 	// +1 to account for the terminator that's written
 	ASSERT_EQ(stream.size(), in.size() + 1);
 
 	std::string out;
-	stream >> out;
+	stream >> hexi::null_terminated(out);
 
 	ASSERT_TRUE(stream.empty());
 	ASSERT_EQ(in, out);
@@ -109,7 +109,7 @@ TEST(binary_stream_pmc, read_write_c_string) {
 	ASSERT_EQ(stream.size(), strlen(in) + 1);
 
 	std::string out;
-	stream >> out;
+	stream >> hexi::null_terminated(out);
 
 	ASSERT_TRUE(stream.empty());
 	ASSERT_EQ(0, strcmp(in, out.c_str()));
@@ -293,4 +293,176 @@ TEST(binary_stream_pmc, set_error_state) {
 	ASSERT_FALSE(stream);
 	ASSERT_FALSE(stream.good());
 	ASSERT_TRUE(stream.state() == hexi::stream_state::user_defined_err);
+}
+
+TEST(binary_streamPMR, StringAdaptor_PrefixedVarint_Long) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+
+	std::string input;
+
+	// encode varint requiring three bytes
+	input.resize_and_overwrite(80'000, [&](char* buffer, const std::size_t size) {
+		for(std::size_t i = 0; i < size; ++i) {
+			buffer[i] = (rand() % 127) + 32; // ASCII a-z
+		}
+
+		return size;
+	});
+	
+	stream << hexi::prefixed_varint(input);
+	std::string output;
+	stream >> hexi::prefixed_varint(output);
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
+	ASSERT_TRUE(stream);
+}
+
+TEST(binary_streamPMR, StringAdaptor_PrefixedVarint_Medium) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+
+	std::string input;
+
+	// encode varint requiring two bytes
+	input.resize_and_overwrite(5'000, [&](char* buffer, const std::size_t size) {
+		for(std::size_t i = 0; i < size; ++i) {
+			buffer[i] = (rand() % 127) + 32; // ASCII a-z
+		}
+
+		return size;
+	});
+	
+	stream << hexi::prefixed_varint(input);
+	std::string output;
+	stream >> hexi::prefixed_varint(output);
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
+	ASSERT_TRUE(stream);
+}
+
+TEST(binary_streamPMR, StringAdaptor_PrefixedVarint_Short) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+
+	std::string input;
+
+	// encode varint requiring one byte
+	input.resize_and_overwrite(127, [&](char* buffer, const std::size_t size) {
+		for(std::size_t i = 0; i < size; ++i) {
+			buffer[i] = (rand() % 127) + 32; // ASCII a-z
+		}
+
+		return size;
+	});
+	
+	stream << hexi::prefixed_varint(input);
+	std::string output;
+	stream >> hexi::prefixed_varint(output);
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
+	ASSERT_TRUE(stream);
+}
+
+TEST(binary_streamPMR, StringAdaptor_Prefixed) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+	const std::string input { "The quick brown fox jumped over the lazy dog" };
+	stream << hexi::prefixed(input);
+	std::string output;
+	stream >> hexi::prefixed(output);
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
+}
+
+TEST(binary_streamPMR, StringAdaptor_Default) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+	const std::string input { "The quick brown fox jumped over the lazy dog" };
+	stream << input;
+	std::string output;
+	stream >> output;
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
+}
+
+TEST(binary_streamPMR, StringAdaptor_Raw) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+	const auto input = std::format("String with {} embedded null", '\0');
+	stream << hexi::raw(input);
+	ASSERT_EQ(input.size(), buffer.size());
+	std::string output;
+	stream >> hexi::null_terminated(output);
+	ASSERT_EQ(output, "String with ");
+	ASSERT_FALSE(stream.empty());
+}
+
+TEST(binary_streamPMR, StringAdaptor_NullTerminated) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+	const std::string input { "We're just normal strings. Innocent strings."};
+	stream << hexi::null_terminated(input);
+	std::string output;
+	stream >> hexi::null_terminated(output);
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
+}
+
+TEST(binary_streamPMR, StringviewAdaptor_Prefixed) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+	std::string_view input { "The quick brown fox jumped over the lazy dog" };
+	stream << hexi::prefixed(input);
+	std::string output;
+	stream >> hexi::prefixed(output);
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
+}
+
+TEST(binary_streamPMR, StringviewAdaptor_Default) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+	std::string_view input { "The quick brown fox jumped over the lazy dog" };
+	stream << input;
+	std::string output;
+	stream >> output;
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
+}
+
+TEST(binary_streamPMR, StringviewAdaptor_Raw) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+	const auto str = std::format("String with {} embedded null", '\0');
+	std::string_view input { str };
+	stream << hexi::raw(input);
+	ASSERT_EQ(input.size(), buffer.size());
+	std::string output;
+	stream >> hexi::null_terminated(output);
+	ASSERT_EQ(output, "String with ");
+	ASSERT_FALSE(stream.empty());
+}
+
+TEST(binary_streamPMR, StringviewAdaptor_NullTerminated) {
+	std::vector<char> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer);
+	hexi::pmc::binary_stream stream(adaptor);
+	std::string_view input { "We're just normal strings. Innocent strings." };
+	stream << hexi::null_terminated(input);
+	ASSERT_EQ(stream.size(), input.size() + 1); // account for the null terminator
+	std::string output;
+	stream >> hexi::null_terminated(output);
+	ASSERT_EQ(input, output);
+	ASSERT_TRUE(stream.empty());
 }


### PR DESCRIPTION
Provides adaptors for explicitly specifying how strings should be handled with being serialised and deserialised.

raw: write the data exactly as in
null_terminated: ensure the string is written with a null terminator - strings with embedded null bytes are *not* allowed (but is only enforced in debug) as retrieving such a string would stop at the first embedded null. This is user error is mostly semantics.
prefixed: prefixes the length before the string, no terminator is written.
prefixed_varint: prefixes the length, encoded as a varint, no terminator is written. This is more compact but slower than `prefixed`

All adaptors can be used both as input and output, with the exception of `raw()`. Retrieving strings written using `raw` requires the user to know specifics about the string content (i.e. whether it has embedded nulls or its length), so `.get()` should be used.