### PR TITLE
Rename check_read_bounds for clarity

### DIFF
--- a/single_include/hexi.h
+++ b/single_include/hexi.h
@@ -419,8 +419,8 @@ namespace hexi {
 
 using namespace detail;
 
-#define STREAM_READ_BOUNDS_CHECK(read_size, ret_var)              \
-	check_read_bounds(read_size);                                 \
+#define STREAM_READ_BOUNDS_ENFORCE(read_size, ret_var)              \
+	enforce_read_bounds(read_size);                                 \
 	                                                              \
 	if constexpr(std::is_same_v<exceptions, no_throw>) {          \
 		if(state_ != stream_state::ok) [[unlikely]] {             \
@@ -446,7 +446,7 @@ private:
 	stream_state state_ = stream_state::ok;
 	const size_type read_limit_;
 
-	inline void check_read_bounds(const size_type read_size) {
+	inline void enforce_read_bounds(const size_type read_size) {
 		if(read_size > buffer_.size()) [[unlikely]] {
 			state_ = stream_state::buff_limit_err;
 
@@ -640,12 +640,12 @@ public:
 	/*** Read ***/
 
 	binary_stream& operator>>(prefixed<std::string> adaptor) {
-		STREAM_READ_BOUNDS_CHECK(sizeof(std::uint32_t), *this);
+		STREAM_READ_BOUNDS_ENFORCE(sizeof(std::uint32_t), *this);
 		std::uint32_t size {};
 		buffer_.read(&size);
 		endian::little_to_native_inplace(size);
 
-		STREAM_READ_BOUNDS_CHECK(size, *this);
+		STREAM_READ_BOUNDS_ENFORCE(size, *this);
 
 		adaptor->resize_and_overwrite(size, [&](char* strbuf, std::size_t size) {
 			buffer_.read(strbuf, size);
@@ -656,7 +656,7 @@ public:
 	}
 
 	binary_stream& operator>>(prefixed<std::string_view> adaptor) {
-		STREAM_READ_BOUNDS_CHECK(sizeof(std::uint32_t), *this);
+		STREAM_READ_BOUNDS_ENFORCE(sizeof(std::uint32_t), *this);
 		std::uint32_t size {};
 		buffer_.read(&size);
 		endian::little_to_native_inplace(size);
@@ -670,10 +670,10 @@ public:
 		// if decoding the varint failed due to detecting a potential read overrun,
 		// we'll trigger the error handling here instead
 		if(!result) {
-			STREAM_READ_BOUNDS_CHECK(1, *this);
+			STREAM_READ_BOUNDS_ENFORCE(1, *this);
 		}
 
-		STREAM_READ_BOUNDS_CHECK(size, *this);
+		STREAM_READ_BOUNDS_ENFORCE(size, *this);
 
 		adaptor->resize_and_overwrite(size, [&](char* strbuf, std::size_t size) {
 			buffer_.read(strbuf, size);
@@ -689,7 +689,7 @@ public:
 		// if decoding the varint failed due to detecting a potential read overrun,
 		// we'll trigger the error handling here instead
 		if(!result) {
-			STREAM_READ_BOUNDS_CHECK(1, *this);
+			STREAM_READ_BOUNDS_ENFORCE(1, *this);
 		}
 		
 		adaptor.str = std::string_view { span<char>(size) };
@@ -704,7 +704,7 @@ public:
 			return *this;
 		}
 
-		STREAM_READ_BOUNDS_CHECK(pos + 1, *this); // include null terminator
+		STREAM_READ_BOUNDS_ENFORCE(pos + 1, *this); // include null terminator
 
 		adaptor->resize_and_overwrite(pos, [&](char* strbuf, std::size_t size) {
 			buffer_.read(strbuf, pos);
@@ -735,7 +735,7 @@ public:
 	template<pod T>
 	requires (!has_shr_override<T, binary_stream>)
 	binary_stream& operator>>(T& data) {
-		STREAM_READ_BOUNDS_CHECK(sizeof(data), *this);
+		STREAM_READ_BOUNDS_ENFORCE(sizeof(data), *this);
 		buffer_.read(&data, sizeof(data));
 		return *this;
 	}
@@ -746,7 +746,7 @@ public:
 	 * @return The destination for the read value.
 	 */
 	void get(arithmetic auto& dest) {
-		STREAM_READ_BOUNDS_CHECK(sizeof(dest), void());
+		STREAM_READ_BOUNDS_ENFORCE(sizeof(dest), void());
 		buffer_.read(&dest, sizeof(dest));
 	}
 
@@ -757,7 +757,7 @@ public:
 	 */
 	template<arithmetic T>
 	T get() {
-		STREAM_READ_BOUNDS_CHECK(sizeof(T), void());
+		STREAM_READ_BOUNDS_ENFORCE(sizeof(T), void());
 		T t{};
 		buffer_.read(&t, sizeof(T));
 		return t;
@@ -771,7 +771,7 @@ public:
 	 */
 	template<endian::conversion conversion>
 	void get(arithmetic auto& dest) {
-		STREAM_READ_BOUNDS_CHECK(sizeof(dest), void());
+		STREAM_READ_BOUNDS_ENFORCE(sizeof(dest), void());
 		buffer_.read(&dest, sizeof(dest));
 		dest = endian::convert<conversion>(dest);
 	}
@@ -784,7 +784,7 @@ public:
 	 */
 	template<arithmetic T, endian::conversion conversion>
 	T get() {
-		STREAM_READ_BOUNDS_CHECK(sizeof(T), void());
+		STREAM_READ_BOUNDS_ENFORCE(sizeof(T), void());
 		T t{};
 		buffer_.read(&t, sizeof(T));
 		return endian::convert<conversion>(t);
@@ -807,7 +807,7 @@ public:
 	 * @param count The number of bytes to be read.
 	 */
 	void get(std::string& dest, size_type size) {
-		STREAM_READ_BOUNDS_CHECK(size, void());
+		STREAM_READ_BOUNDS_ENFORCE(size, void());
 		dest.resize_and_overwrite(size, [&](char* strbuf, size_type len) {
 			buffer_.read(strbuf, len);
 			return len;
@@ -824,7 +824,7 @@ public:
 	void get(T* dest, size_type count) {
 		assert(dest);
 		const auto read_size = count * sizeof(T);
-		STREAM_READ_BOUNDS_CHECK(read_size, void());
+		STREAM_READ_BOUNDS_ENFORCE(read_size, void());
 		buffer_.read(dest, read_size);
 	}
 
@@ -849,7 +849,7 @@ public:
 	template<std::ranges::contiguous_range range>
 	void get(range& dest) {
 		const auto read_size = dest.size() * sizeof(range::value_type);
-		STREAM_READ_BOUNDS_CHECK(read_size, void());
+		STREAM_READ_BOUNDS_ENFORCE(read_size, void());
 		buffer_.read(dest.data(), read_size);
 	}
 
@@ -863,7 +863,7 @@ public:
 	 * @param length The number of bytes to skip.
 	 */
 	void skip(const size_type count) {
-		STREAM_READ_BOUNDS_CHECK(count, void());
+		STREAM_READ_BOUNDS_ENFORCE(count, void());
 		buffer_.skip(count);
 	}
 
@@ -900,7 +900,7 @@ public:
 	 */
 	template<typename out_type = value_type>
 	std::span<out_type> span(size_type count) requires contiguous<buf_type> {
-		STREAM_READ_BOUNDS_CHECK(sizeof(out_type) * count, {});
+		STREAM_READ_BOUNDS_ENFORCE(sizeof(out_type) * count, {});
 		std::span span { reinterpret_cast<out_type*>(buffer_.read_ptr()), count };
 		buffer_.skip(sizeof(out_type) * count);
 		return span;
@@ -3813,7 +3813,7 @@ class binary_stream_reader : virtual public stream_base {
 	std::size_t total_read_;
 	const std::size_t read_limit_;
 
-	void check_read_bounds(std::size_t read_size) {
+	void enforce_read_bounds(std::size_t read_size) {
 		if(read_size > buffer_.size()) [[unlikely]] {
 			set_state(stream_state::buff_limit_err);
 			throw buffer_underrun(read_size, total_read_, buffer_.size());
@@ -3851,11 +3851,11 @@ public:
 
 	binary_stream_reader& operator>>(prefixed<std::string> adaptor) {
 		std::uint32_t size {};
-		check_read_bounds(sizeof(size));
+		enforce_read_bounds(sizeof(size));
 		buffer_.read(&size, sizeof(size));
 		endian::little_to_native_inplace(size);
 
-		check_read_bounds(size);
+		enforce_read_bounds(size);
 
 		adaptor->resize_and_overwrite(size, [&](char* strbuf, std::size_t size) {
 			buffer_.read(strbuf, size);
@@ -3871,11 +3871,11 @@ public:
 		// if decoding the varint failed due to detecting a potential read overrun,
 		// we'll trigger the error handling here instead
 		if(!result) {
-			check_read_bounds(1);
+			enforce_read_bounds(1);
 			std::unreachable();
 		}
 
-		check_read_bounds(size);
+		enforce_read_bounds(size);
 
 		adaptor->resize_and_overwrite(size, [&](char* strbuf, std::size_t size) {
 			buffer_.read(strbuf, size);
@@ -3893,7 +3893,7 @@ public:
 			return *this;
 		}
 
-		check_read_bounds(pos + 1); // include null terminator
+		enforce_read_bounds(pos + 1); // include null terminator
 
 		adaptor->resize_and_overwrite(pos, [&](char* strbuf, std::size_t size) {
 			buffer_.read(strbuf, pos);
@@ -3915,13 +3915,13 @@ public:
 	template<pod T>
 	requires (!has_shr_override<T, binary_stream_reader>)
 	binary_stream_reader& operator>>(T& data) {
-		check_read_bounds(sizeof(data));
+		enforce_read_bounds(sizeof(data));
 		buffer_.read(&data, sizeof(data));
 		return *this;
 	}
 
 	binary_stream_reader& operator>>(pod auto& data) {
-		check_read_bounds(sizeof(data));
+		enforce_read_bounds(sizeof(data));
 		buffer_.read(&data, sizeof(data));
 		return *this;
 	}
@@ -3942,7 +3942,7 @@ public:
 	 * @param count The number of bytes to be read.
 	 */
 	void get(std::string& dest, std::size_t size) {
-		check_read_bounds(size);
+		enforce_read_bounds(size);
 		dest.resize_and_overwrite(size, [&](char* strbuf, std::size_t len) {
 			buffer_.read(strbuf, len);
 			return len;
@@ -3959,7 +3959,7 @@ public:
 	void get(T* dest, std::size_t count) {
 		assert(dest);
 		const auto read_size = count * sizeof(T);
-		check_read_bounds(read_size);
+		enforce_read_bounds(read_size);
 		buffer_.read(dest, read_size);
 	}
 
@@ -3984,7 +3984,7 @@ public:
 	template<std::ranges::contiguous_range range>
 	void get(range& dest) {
 		const auto read_size = dest.size() * sizeof(range::value_type);
-		check_read_bounds(read_size);
+		enforce_read_bounds(read_size);
 		buffer_.read(dest.data(), read_size);
 	}
 
@@ -3995,7 +3995,7 @@ public:
 	 */
 	template<arithmetic T>
 	T get() {
-		check_read_bounds(sizeof(T));
+		enforce_read_bounds(sizeof(T));
 		T t{};
 		buffer_.read(&t, sizeof(T));
 		return t;
@@ -4007,7 +4007,7 @@ public:
 	 * @return The arithmetic value.
 	 */
 	void get(arithmetic auto& dest) {
-		check_read_bounds(sizeof(dest));
+		enforce_read_bounds(sizeof(dest));
 		buffer_.read(&dest, sizeof(dest));
 	}
 
@@ -4019,7 +4019,7 @@ public:
 	 */
 	template<endian::conversion conversion>
 	void get(arithmetic auto& dest) {
-		check_read_bounds(sizeof(dest));
+		enforce_read_bounds(sizeof(dest));
 		buffer_.read(&dest, sizeof(dest));
 		dest = endian::convert<conversion>(dest);
 	}
@@ -4032,7 +4032,7 @@ public:
 	 */
 	template<arithmetic T, endian::conversion conversion>
 	T get() {
-		check_read_bounds(sizeof(T));
+		enforce_read_bounds(sizeof(T));
 		T t{};
 		buffer_.read(&t, sizeof(T));
 		return endian::convert<conversion>(t);
@@ -4050,7 +4050,7 @@ public:
 	 * @param length The number of bytes to skip.
 	 */
 	void skip(std::size_t count) {
-		check_read_bounds(count);
+		enforce_read_bounds(count);
 		buffer_.skip(count);
 	}
 


### PR DESCRIPTION
Make it slightly clearer that it actually enforces the bounds.