### PR TITLE
Improve ergonomics of using hexi::no_throw by aiding deduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,15 @@ The default error handling mechanism is exceptions. Upon encountering a problem 
 - `hexi::buffer_underrun` - attempt to read out of bounds
 - `hexi::stream_read_limit` - attempt to read more than the imposed limit
 
-Exceptions from `binary_stream` can be disabled by specifying `no_throw` as a template argument, as shown:
+Exceptions from `binary_stream` can be disabled by specifying `no_throw` as an argument. This argument eliminates exception branches at compile-time, so there's zero run-time overhead.
 ```cpp
-hexi::binary_stream<buf_type, hexi::no_throw> stream(...);
+hexi::binary_stream stream(buffer, hexi::no_throw);
 ```
 While this prevents `binary_stream` itself from throwing, it does not prevent propagation of exceptions from lower levels. For example, a wrapped `std::vector` could still throw `std::bad_alloc` if allocation fails when writing to it.
 
 Regardless of the error handling mechanism you use, the state of a `binary_stream` can be checked as follows:
 ```cpp
-hexi::binary_stream<buf_type, hexi::no_throw> stream(...);
+hexi::binary_stream stream(buffer, hexi::no_throw);
 // ... assume an error happens
 
 // simplest way to check whether any errors have occurred

--- a/include/hexi/binary_stream.h
+++ b/include/hexi/binary_stream.h
@@ -30,13 +30,13 @@ using namespace detail;
 #define STREAM_READ_BOUNDS_ENFORCE(read_size, ret_var)            \
 	enforce_read_bounds(read_size);                               \
 	                                                              \
-	if constexpr(std::is_same_v<exceptions, no_throw>) {          \
+	if constexpr(std::is_same_v<exceptions, no_throw_t>) {        \
 		if(state_ != stream_state::ok) [[unlikely]] {             \
 			return ret_var;                                       \
 		}                                                         \
 	}
 
-template<byte_oriented buf_type, std::derived_from<except_tag> exceptions = allow_throw>
+template<byte_oriented buf_type, std::derived_from<except_tag> exceptions = allow_throw_t>
 class binary_stream final {
 public:
 	using size_type          = typename buf_type::size_type;
@@ -58,7 +58,7 @@ private:
 		if(read_size > buffer_.size()) [[unlikely]] {
 			state_ = stream_state::buff_limit_err;
 
-			if constexpr(std::is_same_v<exceptions, allow_throw>) {
+			if constexpr(std::is_same_v<exceptions, allow_throw_t>) {
 				throw buffer_underrun(read_size, total_read_, buffer_.size());
 			}
 
@@ -71,7 +71,7 @@ private:
 			if(read_size > max_read_remaining) [[unlikely]] {
 				state_ = stream_state::read_limit_err;
 
-				if constexpr(std::is_same_v<exceptions, allow_throw>) {
+				if constexpr(std::is_same_v<exceptions, allow_throw_t>) {
 					throw stream_read_limit(read_size, total_read_, read_limit_);
 				}
 
@@ -86,6 +86,12 @@ public:
 	explicit binary_stream(buf_type& source, size_type read_limit = 0)
 		: buffer_(source),
 		  read_limit_(read_limit) {};
+
+	explicit binary_stream(buf_type& source, size_type read_limit, exceptions)
+		: binary_stream(source, read_limit) {}
+
+	explicit binary_stream(buf_type& source, exceptions)
+		: binary_stream(source, 0) {}
 
 	binary_stream(binary_stream&& rhs) noexcept
 		: buffer_(rhs.buffer_), 

--- a/include/hexi/shared.h
+++ b/include/hexi/shared.h
@@ -21,8 +21,12 @@ struct is_non_contiguous {};
 struct supported {};
 struct unsupported {};
 struct except_tag{};
-struct allow_throw : except_tag{};
-struct no_throw : except_tag{};
+struct allow_throw_t : except_tag{};
+struct no_throw_t : except_tag{};
+
+constexpr static no_throw_t no_throw = no_throw_t();
+constexpr static allow_throw_t allow_throw = allow_throw_t();
+
 
 #define STRING_ADAPTOR(adaptor_name)           \
 template<typename string_type>                 \

--- a/tests/binary_stream.cpp
+++ b/tests/binary_stream.cpp
@@ -395,7 +395,7 @@ TEST(binary_stream, static_buffer_underrun) {
 
 TEST(binary_stream, static_buffer_underrun_noexcept) {
 	hexi::static_buffer<char, 4> buffer;
-	hexi::binary_stream<decltype(buffer), hexi::no_throw> stream(buffer);
+	hexi::binary_stream stream(buffer, hexi::no_throw);
 	std::uint32_t output = 0;
 	stream << output;
 	stream >> output;


### PR DESCRIPTION
Old (still available but with no_throw_t):
hexi::binary_stream<buffer_type, hexi::no_throw> stream(buffer);

New:
hexi::binary_stream stream(buffer, hexi::no_throw);