### PR TITLE
Improve error handling strategy & introduce internal macro for safer reading

### DIFF
--- a/include/hexi/pmc/binary_stream_reader.h
+++ b/include/hexi/pmc/binary_stream_reader.h
@@ -48,8 +48,10 @@ class binary_stream_reader : virtual public stream_base {
 	}
 
 	inline void read(void* dest, const std::size_t size) {
-		enforce_read_bounds(size);
-		buffer_.read(dest, size);
+		if(state() == stream_state::ok) [[likely]] {
+			enforce_read_bounds(size);
+			buffer_.read(dest, size);
+		}
 	}
 
 public:

--- a/include/hexi/pmc/binary_stream_writer.h
+++ b/include/hexi/pmc/binary_stream_writer.h
@@ -29,8 +29,10 @@ class binary_stream_writer : virtual public stream_base {
 	std::size_t total_write_;
 
 	inline void write(const void* data, const std::size_t size) {
-		buffer_.write(data, size);
-		total_write_ += size;
+		if(state() == stream_state::ok) [[likely]] {
+			buffer_.write(data, size);
+			total_write_ += size;
+		}
 	}
 
 public:


### PR DESCRIPTION
Binary stream will now refuse to continue any further reads or writes once it enters an error state, until explicitly cleared.