### PR TITLE
Ensure adaptors report size correctly when using std::array with init_empty

### DIFF
--- a/include/hexi/binary_stream.h
+++ b/include/hexi/binary_stream.h
@@ -98,7 +98,7 @@ private:
 
 	template<typename T>
 	inline void advance_write(T&& arg) {
-		total_write_ += sizeof(std::decay_t<T>);
+		total_write_ += sizeof(T);
 	}
 
 	template<typename T, typename U>

--- a/include/hexi/buffer_adaptor.h
+++ b/include/hexi/buffer_adaptor.h
@@ -183,7 +183,7 @@ public:
 	 * @return The number of bytes of data available to read within the container.
 	 */
 	size_type size() const {
-		return buffer_.size() - read_;
+		return write_ - read_;
 	}
 
 	/**

--- a/include/hexi/pmc/buffer_base.h
+++ b/include/hexi/pmc/buffer_base.h
@@ -11,6 +11,10 @@
 namespace hexi::pmc {
 
 class buffer_base {
+protected:
+	std::size_t read_ = 0;
+	std::size_t write_ = 0;
+
 public:
 	virtual std::size_t size() const = 0;
 	virtual bool empty() const = 0;

--- a/include/hexi/pmc/buffer_read_adaptor.h
+++ b/include/hexi/pmc/buffer_read_adaptor.h
@@ -24,12 +24,10 @@ template<byte_oriented buf_type>
 requires std::ranges::contiguous_range<buf_type>
 class buffer_read_adaptor : public buffer_read {
 	buf_type& buffer_;
-	std::size_t read_;
 
 public:
 	buffer_read_adaptor(buf_type& buffer)
-		: buffer_(buffer),
-		  read_(0) {}
+		: buffer_(buffer) {}
 
 	/**
 	 * @brief Reads a number of bytes to the provided buffer.
@@ -95,7 +93,7 @@ public:
 	 * @return The number of bytes of data available to read within the stream.
 	 */
 	std::size_t size() const override {
-		return buffer_.size() - read_;
+		return write_ - read_;
 	}
 
 	/**
@@ -105,7 +103,7 @@ public:
 	 */
 	[[nodiscard]]
 	bool empty() const override {
-		return !(buffer_.size() - read_);
+		return read_ == write_;
 	}
 
 	/**

--- a/include/hexi/pmc/buffer_write_adaptor.h
+++ b/include/hexi/pmc/buffer_write_adaptor.h
@@ -23,16 +23,15 @@ template<byte_oriented buf_type>
 requires std::ranges::contiguous_range<buf_type>
 class buffer_write_adaptor : public buffer_write {
 	buf_type& buffer_;
-	std::size_t write_;
 
 public:
 	buffer_write_adaptor(buf_type& buffer)
-		: buffer_(buffer),
-		  write_(buffer.size()) {}
+		: buffer_(buffer) {
+		write_ = buffer.size();
+	}
 
 	buffer_write_adaptor(buf_type& buffer, init_empty_t)
-		: buffer_(buffer),
-		  write_(0) {}
+		: buffer_(buffer) {}
 
 	/**
 	 * @brief Write data to the container.

--- a/tests/binary_stream.cpp
+++ b/tests/binary_stream.cpp
@@ -1077,3 +1077,12 @@ TEST(binary_stream, prefixed_containers) {
 	EXPECT_EQ(objects.size(), output_objs.size());
 	ASSERT_EQ(objects, output_objs);
 }
+
+TEST(binary_stream, std_array_size) {
+	std::array<char, 16> buffer;
+	hexi::buffer_adaptor adaptor(buffer, hexi::init_empty);
+	hexi::binary_stream stream(adaptor);
+	ASSERT_TRUE(adaptor.empty());
+	ASSERT_EQ(adaptor.size(), 0);
+	ASSERT_EQ(stream.size(), 0);
+}

--- a/tests/binary_stream_pmc.cpp
+++ b/tests/binary_stream_pmc.cpp
@@ -298,7 +298,7 @@ TEST(binary_stream_pmc, set_error_state) {
 	ASSERT_TRUE(stream.state() == hexi::stream_state::user_defined_err);
 }
 
-TEST(binary_stream_pmr, string_adaptor_prefixed_varint_long) {
+TEST(binary_stream_pmc, string_adaptor_prefixed_varint_long) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -322,7 +322,7 @@ TEST(binary_stream_pmr, string_adaptor_prefixed_varint_long) {
 	ASSERT_TRUE(stream);
 }
 
-TEST(binary_stream_pmr, string_adaptor_prefixed_varint_medium) {
+TEST(binary_stream_pmc, string_adaptor_prefixed_varint_medium) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -346,7 +346,7 @@ TEST(binary_stream_pmr, string_adaptor_prefixed_varint_medium) {
 	ASSERT_TRUE(stream);
 }
 
-TEST(binary_stream_pmr, string_adaptor_prefixed_varint_short) {
+TEST(binary_stream_pmc, string_adaptor_prefixed_varint_short) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -370,7 +370,7 @@ TEST(binary_stream_pmr, string_adaptor_prefixed_varint_short) {
 	ASSERT_TRUE(stream);
 }
 
-TEST(binary_stream_pmr, string_adaptor_prefixed) {
+TEST(binary_stream_pmc, string_adaptor_prefixed) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -382,7 +382,7 @@ TEST(binary_stream_pmr, string_adaptor_prefixed) {
 	ASSERT_TRUE(stream.empty());
 }
 
-TEST(binary_stream_pmr, string_adaptor_default) {
+TEST(binary_stream_pmc, string_adaptor_default) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -394,7 +394,7 @@ TEST(binary_stream_pmr, string_adaptor_default) {
 	ASSERT_TRUE(stream.empty());
 }
 
-TEST(binary_stream_pmr, string_adaptor_raw) {
+TEST(binary_stream_pmc, string_adaptor_raw) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -407,7 +407,7 @@ TEST(binary_stream_pmr, string_adaptor_raw) {
 	ASSERT_FALSE(stream.empty());
 }
 
-TEST(binary_stream_pmr, string_adaptor_null_terminated) {
+TEST(binary_stream_pmc, string_adaptor_null_terminated) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -419,7 +419,7 @@ TEST(binary_stream_pmr, string_adaptor_null_terminated) {
 	ASSERT_TRUE(stream.empty());
 }
 
-TEST(binary_stream_pmr, string_view_adaptor_prefixed) {
+TEST(binary_stream_pmc, string_view_adaptor_prefixed) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -431,7 +431,7 @@ TEST(binary_stream_pmr, string_view_adaptor_prefixed) {
 	ASSERT_TRUE(stream.empty());
 }
 
-TEST(binary_stream_pmr, string_view_adaptor_default) {
+TEST(binary_stream_pmc, string_view_adaptor_default) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -443,7 +443,7 @@ TEST(binary_stream_pmr, string_view_adaptor_default) {
 	ASSERT_TRUE(stream.empty());
 }
 
-TEST(binary_stream_pmr, string_view_adaptor_raw) {
+TEST(binary_stream_pmc, string_view_adaptor_raw) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -457,7 +457,7 @@ TEST(binary_stream_pmr, string_view_adaptor_raw) {
 	ASSERT_FALSE(stream.empty());
 }
 
-TEST(binary_stream_pmr, string_view_adaptor_null_terminated) {
+TEST(binary_stream_pmc, string_view_adaptor_null_terminated) {
 	std::vector<char> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -470,7 +470,7 @@ TEST(binary_stream_pmr, string_view_adaptor_null_terminated) {
 	ASSERT_TRUE(stream.empty());
 }
 
-TEST(binary_stream_pmr, std_array) {
+TEST(binary_stream_pmc, std_array) {
 	std::array<char, 128> buffer{};
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -490,7 +490,7 @@ TEST(binary_stream_pmr, std_array) {
 	ASSERT_EQ(input, output);
 }
 
-TEST(binary_stream_pmr, total_write_consistency) {
+TEST(binary_stream_pmc, total_write_consistency) {
 	std::array<char, 1024> buffer;
 	hexi::pmc::buffer_adaptor adaptor(buffer, hexi::init_empty);
 	hexi::pmc::binary_stream stream(adaptor);
@@ -709,4 +709,13 @@ TEST(binary_stream_pmc, prefixed_containers) {
 	stream >> hexi::prefixed(output_objs);
 	EXPECT_EQ(objects.size(), output_objs.size());
 	ASSERT_EQ(objects, output_objs);
+}
+
+TEST(binary_stream_pmc, std_array_size) {
+	std::array<char, 16> buffer;
+	hexi::pmc::buffer_adaptor adaptor(buffer, hexi::init_empty);
+	hexi::pmc::binary_stream stream(adaptor);
+	ASSERT_TRUE(adaptor.empty());
+	ASSERT_EQ(adaptor.size(), 0);
+	ASSERT_EQ(stream.size(), 0);
 }

--- a/tests/buffer_adaptor.cpp
+++ b/tests/buffer_adaptor.cpp
@@ -41,6 +41,7 @@ TEST(buffer_adaptor, resize_match) {
 	hexi::buffer_adaptor adaptor(buffer);
 	ASSERT_EQ(adaptor.size(), buffer.size());
 	buffer.emplace_back(6);
+	adaptor.advance_write(1);
 	ASSERT_EQ(adaptor.size(), buffer.size());
 }
 

--- a/tests/buffer_adaptor_pmc.cpp
+++ b/tests/buffer_adaptor_pmc.cpp
@@ -41,6 +41,7 @@ TEST(buffer_adaptor_pmc, resize_match) {
 	hexi::pmc::buffer_adaptor adaptor(buffer);
 	ASSERT_EQ(adaptor.size(), buffer.size());
 	buffer.emplace_back(6);
+	adaptor.advance_write(1);
 	ASSERT_EQ(adaptor.size(), buffer.size());
 }
 


### PR DESCRIPTION
All it took was breaking encapsulation.