### PR TITLE
Fix exception/error state when using static_buffer with buffer_adaptor

### DIFF
--- a/include/hexi/static_buffer.h
+++ b/include/hexi/static_buffer.h
@@ -147,6 +147,17 @@ public:
 	}
 
 	/**
+	 * @brief Resizes the buffer.
+	 * 
+	 * @param size The new size of the buffer.
+	 * 
+	 */
+	void resize(size_type size) {
+		assert(size <= buffer_.size());
+		write_ = size;
+	}
+
+	/**
 	 * @brief Clears the container.
 	 */
 	void clear() {

--- a/include/hexi/static_buffer.h
+++ b/include/hexi/static_buffer.h
@@ -153,7 +153,10 @@ public:
 	 * 
 	 */
 	void resize(size_type size) {
-		assert(size <= buffer_.size());
+		if(size > buffer_.size()) {
+			throw exception("attempted to resize static_buffer to larger than capacity");
+		}
+
 		write_ = size;
 	}
 

--- a/single_include/hexi.h
+++ b/single_include/hexi.h
@@ -1689,7 +1689,7 @@ public:
 	 * @return Pointer to the location within the buffer where the next write
 	 * will be made.
 	 */
-	auto write_ptr() const  {
+	auto write_ptr() const {
 		return buffer_.data() + write_;
 	}
 
@@ -3824,6 +3824,17 @@ public:
 	void advance_write(size_type bytes) {
 		assert(free() >= bytes);
 		write_ += bytes;
+	}
+
+	/**
+	 * @brief Resizes the buffer.
+	 * 
+	 * @param size The new size of the buffer.
+	 * 
+	 */
+	void resize(size_type size) {
+		assert(size <= buffer_.size());
+		write_ = size;
 	}
 
 	/**

--- a/single_include/hexi.h
+++ b/single_include/hexi.h
@@ -3833,7 +3833,10 @@ public:
 	 * 
 	 */
 	void resize(size_type size) {
-		assert(size <= buffer_.size());
+		if(size > buffer_.size()) {
+			throw exception("attempted to resize static_buffer to larger than capacity");
+		}
+
 		write_ = size;
 	}
 

--- a/tests/binary_stream.cpp
+++ b/tests/binary_stream.cpp
@@ -407,6 +407,21 @@ TEST(binary_stream, static_buffer_underrun_noexcept) {
 	ASSERT_EQ(output, 0);
 }
 
+TEST(binary_stream, static_buffer_adaptor_regression) {
+	hexi::static_buffer<char, 128> buffer;
+	hexi::buffer_adaptor adaptor(buffer);
+	hexi::binary_stream stream(buffer);
+	stream << 1 << 2 << 3;
+
+	std::string foo { "foo " };
+	stream << foo;
+
+	std::string_view sv;
+	stream.skip(sizeof(int) * 3);
+	stream >> sv;
+	ASSERT_TRUE(stream);
+}
+
 TEST(binary_stream, put_integral_literals) {
 	hexi::static_buffer<char, 64> buffer;
 	hexi::binary_stream stream(buffer);

--- a/tests/binary_stream.cpp
+++ b/tests/binary_stream.cpp
@@ -422,6 +422,24 @@ TEST(binary_stream, static_buffer_adaptor_regression) {
 	ASSERT_TRUE(stream);
 }
 
+TEST(binary_stream, static_buffer_adaptor_exception_regression) {
+	hexi::static_buffer<char, 16> buffer;
+	hexi::buffer_adaptor adaptor(buffer);
+	hexi::binary_stream stream(buffer);
+	std::string_view str { "This is a string that is longer than the size of the buffer..." };
+	ASSERT_THROW(stream << str, hexi::exception);
+	ASSERT_FALSE(stream);
+}
+
+TEST(binary_stream, static_buffer_adaptor_no_exception_regression) {
+	hexi::static_buffer<char, 16> buffer;
+	hexi::buffer_adaptor adaptor(buffer);
+	hexi::binary_stream stream(buffer, hexi::no_throw);
+	std::string_view str { "This is a string that is longer than the size of the buffer..." };
+	ASSERT_NO_THROW(stream << str);
+	ASSERT_FALSE(stream);
+
+}
 TEST(binary_stream, put_integral_literals) {
 	hexi::static_buffer<char, 64> buffer;
 	hexi::binary_stream stream(buffer);


### PR DESCRIPTION
`static_buffer` wasn't previously usable with `buffer_adaptor` but the changes made to allow for writable `std::array`s have made it compatible. 

Due to the interface differences, using `static_buffer` with `buffer_adaptor` would throw an exception (or set the error state) since `size()` reports the number of readable bytes available, unlike `std::array`, where it's a capacity constant. This caused writing to `static_buffer` to fail with an out of space error.

Adding `resize()` allows `buffer_adaptor` to effectively advance the write cursor and use it as it would any other contiguous buffer.

There's no reason to use `static_buffer` with `buffer_adaptor`, but may as well fix it so it works.