### PR TITLE
Remove duplicate header in CMakeLists.txt

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -11,7 +11,6 @@ set(HEADERS
     hexi/dynamic_buffer.h
     hexi/dynamic_tls_buffer.h
     hexi/shared.h
-    hexi/exception.h
     hexi/buffer_adaptor.h
     hexi/buffer_sequence.h
     hexi/binary_stream.h


### PR DESCRIPTION
Clean up duplicate header entry in CMake configuration.

No functional changes.